### PR TITLE
Adjust splash cursor trail

### DIFF
--- a/src/components/SplashCursor.tsx
+++ b/src/components/SplashCursor.tsx
@@ -88,6 +88,9 @@ const SplashCursor = ({
     };
 
     let pointers = [new (pointerPrototype as any)()];
+    const baseDissipation = config.DENSITY_DISSIPATION;
+    const fastDissipation = baseDissipation * 2;
+    let lastPointerTime = Date.now();
 
     const { gl, ext } = getWebGLContext(canvas);
     if (!ext.supportLinearFiltering) {
@@ -189,6 +192,9 @@ const SplashCursor = ({
     function updateFrame() {
       const dt = calcDeltaTime();
       if (resizeCanvas()) initFramebuffers();
+      if (Date.now() - lastPointerTime > 100) {
+        config.DENSITY_DISSIPATION = fastDissipation;
+      }
       updateColors(dt);
       applyInputs();
       step(dt);
@@ -381,6 +387,13 @@ const SplashCursor = ({
       pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY);
       pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
       pointer.color = color;
+      const speed = Math.hypot(pointer.deltaX, pointer.deltaY);
+      lastPointerTime = Date.now();
+      if (speed < 0.002) {
+        config.DENSITY_DISSIPATION = fastDissipation;
+      } else {
+        config.DENSITY_DISSIPATION = baseDissipation;
+      }
     }
 
     function updatePointerUpData(pointer: any) {

--- a/src/components/splash-cursor/color-utils.ts
+++ b/src/components/splash-cursor/color-utils.ts
@@ -46,9 +46,10 @@ export function HSVtoRGB(h: number, s: number, v: number) {
 }
 
 export function generateColor() {
-  let c = HSVtoRGB(Math.random(), 1.0, 1.0);
+  const c = HSVtoRGB(Math.random(), 1.0, 1.0);
   c.r *= 0.15;
   c.g *= 0.15;
   c.b *= 0.15;
   return c;
 }
+


### PR DESCRIPTION
## Summary
- restore original random color generation
- make cursor trail fade quicker when mouse slows or stops

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841ba8ad9bc8327a4333a165e810306