### PR TITLE
Improve home carousel and spacing

### DIFF
--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import type { CarouselApi } from '@/components/ui/carousel';
 import {
   Carousel,
   CarouselContent,
@@ -11,6 +12,7 @@ import { ArrowRight } from 'lucide-react';
 
 const HeroCarousel = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
+  const [api, setApi] = useState<CarouselApi>();
 
   const slides = [
     {
@@ -39,12 +41,26 @@ const HeroCarousel = () => {
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentSlide((prev) => (prev + 1) % slides.length);
-    }, 10000);
+    }, 5000);
     return () => clearInterval(interval);
   }, [slides.length]);
 
+  useEffect(() => {
+    if (!api) return;
+    api.scrollTo(currentSlide);
+  }, [api, currentSlide]);
+
+  useEffect(() => {
+    if (!api) return;
+    const onSelect = () => setCurrentSlide(api.selectedScrollSnap());
+    api.on('select', onSelect);
+    return () => {
+      api.off('select', onSelect);
+    };
+  }, [api]);
+
   return (
-    <Carousel className="w-full" opts={{ loop: true }}>
+    <Carousel className="w-full" opts={{ loop: true }} setApi={setApi}>
       <CarouselContent>
         {slides.map((slide, index) => (
           <CarouselItem key={index}>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,14 +34,14 @@ const Index = () => {
       <Layout>
       {/* <SplashCursor />  // Removed cursor trail for now */}
       {/* Hero Section with Carousel */}
-      <section className="py-24 bg-gradient-to-br from-conexa-light-grey via-white to-blue-50">
+      <section className="py-16 bg-gradient-to-br from-conexa-light-grey via-white to-blue-50">
         <div className="container mx-auto px-4">
           <HeroCarousel />
         </div>
       </section>
 
       {/* Social Proof Banner */}
-      <section className="py-12 bg-white border-b border-gray-100">
+      <section className="py-8 bg-white border-b border-gray-100">
         <div className="container mx-auto px-4">
           <div className="text-center">
             <p className="font-inter text-gray-600 mb-4">
@@ -63,7 +63,7 @@ const Index = () => {
       </section>
 
       {/* Results Section */}
-      <section className="py-16 bg-gradient-to-r from-conexa-primary to-blue-600">
+      <section className="py-12 bg-gradient-to-r from-conexa-primary to-blue-600">
         <div className="container mx-auto px-4">
           <div className="text-center mb-8">
             <h2 className="font-poppins font-semibold text-3xl text-white mb-4">
@@ -100,7 +100,7 @@ const Index = () => {
       </section>
 
       {/* Features Section */}
-      <section className="py-20 bg-white">
+      <section className="py-16 bg-white">
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-16">
@@ -209,7 +209,7 @@ const Index = () => {
       </section>
 
       {/* Testimonials Section */}
-      <section className="py-20 bg-gradient-to-br from-conexa-light-grey to-blue-50">
+      <section className="py-16 bg-gradient-to-br from-conexa-light-grey to-blue-50">
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <h2 className="font-poppins font-semibold text-4xl text-gray-900 text-center mb-16">
@@ -275,7 +275,7 @@ const Index = () => {
       </section>
 
       {/* FAQ Section */}
-      <section className="py-20 bg-white">
+      <section className="py-16 bg-white">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <h2 className="font-poppins font-semibold text-4xl text-gray-900 text-center mb-16">
@@ -346,7 +346,7 @@ const Index = () => {
       </section>
 
       {/* Pricing and CTA */}
-      <section className="py-16 bg-gradient-to-br from-conexa-primary to-blue-600">
+      <section className="py-12 bg-gradient-to-br from-conexa-primary to-blue-600">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="font-poppins font-semibold text-4xl text-white mb-6">


### PR DESCRIPTION
## Summary
- autoplay home hero carousel every 5 seconds
- wire carousel API so bullets follow slide changes
- reduce vertical spacing between homepage sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684221c36c648327afe877d3f0856a7b