### PR TITLE
Add individual module pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,23 @@ import Blog from "./pages/Blog";
 import BlogPost from "./pages/BlogPost";
 import Contact from "./pages/Contact";
 import Modules from "./pages/Modules";
-import ModuleDetail from "./pages/ModuleDetail";
+import OfficialNotices from "./pages/modules/official-notices";
+import ChatRoom from "./pages/modules/chat-room";
+import Quiz from "./pages/modules/quiz";
+import BulletinBoard from "./pages/modules/bulletin-board";
+import Documents from "./pages/modules/documents";
+import WiseOwl from "./pages/modules/wise-owl";
+import SharedTasks from "./pages/modules/shared-tasks";
+import Security from "./pages/modules/security";
+import Alarm from "./pages/modules/alarm";
+import NoiseAlerts from "./pages/modules/noise-alerts";
+import Marketplace from "./pages/modules/marketplace";
+import HomeRepairs from "./pages/modules/home-repairs";
+import ParkingSharing from "./pages/modules/parking-sharing";
+import SharedRides from "./pages/modules/shared-rides";
+import LocalPosts from "./pages/modules/local-posts";
+import BusinessNetworking from "./pages/modules/business-networking";
+import ConferenceRooms from "./pages/modules/conference-rooms";
 import Pricing from "./pages/Pricing";
 import Benefits from "./pages/Benefits";
 import HowItWorks from "./pages/HowItWorks";
@@ -23,7 +39,23 @@ function App() {
         <Route path="/blog/:id" element={<BlogPost />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/modules" element={<Modules />} />
-        <Route path="/modules/:id" element={<ModuleDetail />} />
+        <Route path="/modules/official-notices" element={<OfficialNotices />} />
+        <Route path="/modules/chat-room" element={<ChatRoom />} />
+        <Route path="/modules/quiz" element={<Quiz />} />
+        <Route path="/modules/bulletin-board" element={<BulletinBoard />} />
+        <Route path="/modules/documents" element={<Documents />} />
+        <Route path="/modules/wise-owl" element={<WiseOwl />} />
+        <Route path="/modules/shared-tasks" element={<SharedTasks />} />
+        <Route path="/modules/security" element={<Security />} />
+        <Route path="/modules/alarm" element={<Alarm />} />
+        <Route path="/modules/noise-alerts" element={<NoiseAlerts />} />
+        <Route path="/modules/marketplace" element={<Marketplace />} />
+        <Route path="/modules/home-repairs" element={<HomeRepairs />} />
+        <Route path="/modules/parking-sharing" element={<ParkingSharing />} />
+        <Route path="/modules/shared-rides" element={<SharedRides />} />
+        <Route path="/modules/local-posts" element={<LocalPosts />} />
+        <Route path="/modules/business-networking" element={<BusinessNetworking />} />
+        <Route path="/modules/conference-rooms" element={<ConferenceRooms />} />
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/benefits" element={<Benefits />} />
         <Route path="/how-it-works" element={<HowItWorks />} />

--- a/src/pages/modules/alarm.tsx
+++ b/src/pages/modules/alarm.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const Alarm = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Alarm
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Alarm;

--- a/src/pages/modules/bulletin-board.tsx
+++ b/src/pages/modules/bulletin-board.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const BulletinBoard = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Bulletin Board
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default BulletinBoard;

--- a/src/pages/modules/business-networking.tsx
+++ b/src/pages/modules/business-networking.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const BusinessNetworking = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Business Networking
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default BusinessNetworking;

--- a/src/pages/modules/chat-room.tsx
+++ b/src/pages/modules/chat-room.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const ChatRoom = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Chat Room
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default ChatRoom;

--- a/src/pages/modules/conference-rooms.tsx
+++ b/src/pages/modules/conference-rooms.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const ConferenceRooms = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Conference Rooms
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default ConferenceRooms;

--- a/src/pages/modules/documents.tsx
+++ b/src/pages/modules/documents.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const Documents = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Documents
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Documents;

--- a/src/pages/modules/home-repairs.tsx
+++ b/src/pages/modules/home-repairs.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const HomeRepairs = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Home Repairs
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default HomeRepairs;

--- a/src/pages/modules/local-posts.tsx
+++ b/src/pages/modules/local-posts.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const LocalPosts = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Local Posts
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default LocalPosts;

--- a/src/pages/modules/marketplace.tsx
+++ b/src/pages/modules/marketplace.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const Marketplace = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Marketplace
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Marketplace;

--- a/src/pages/modules/noise-alerts.tsx
+++ b/src/pages/modules/noise-alerts.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const NoiseAlerts = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Noise Alerts
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default NoiseAlerts;

--- a/src/pages/modules/official-notices.tsx
+++ b/src/pages/modules/official-notices.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const OfficialNotices = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Official Notices
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default OfficialNotices;

--- a/src/pages/modules/parking-sharing.tsx
+++ b/src/pages/modules/parking-sharing.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const ParkingSharing = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Parking Sharing
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default ParkingSharing;

--- a/src/pages/modules/quiz.tsx
+++ b/src/pages/modules/quiz.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const Quiz = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Quiz
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Quiz;

--- a/src/pages/modules/security.tsx
+++ b/src/pages/modules/security.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const Security = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Security
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default Security;

--- a/src/pages/modules/shared-rides.tsx
+++ b/src/pages/modules/shared-rides.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const SharedRides = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Shared Rides
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default SharedRides;

--- a/src/pages/modules/shared-tasks.tsx
+++ b/src/pages/modules/shared-tasks.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const SharedTasks = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Shared Tasks
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default SharedTasks;

--- a/src/pages/modules/wise-owl.tsx
+++ b/src/pages/modules/wise-owl.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+const WiseOwl = () => (
+  <Layout>
+    <section className="py-20 bg-white">
+      <div className="container mx-auto px-4 text-center">
+        <h1 className="font-poppins font-semibold text-4xl text-gray-900">
+          Wise Owl
+        </h1>
+      </div>
+    </section>
+  </Layout>
+);
+
+export default WiseOwl;


### PR DESCRIPTION
## Summary
- add placeholder pages for each module
- route each module ID to its own page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68423212734883278c495b7232615785