### PR TITLE
Fix chat room module rendering

### DIFF
--- a/src/pages/modules/chat-room.tsx
+++ b/src/pages/modules/chat-room.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Layout from '@/components/Layout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -30,7 +30,7 @@ import {
 } from '@/components/ui/accordion';
 
 const ModuleDetail = () => {
-  const { id } = useParams();
+  const id = 'chat-room';
 
   // Module data - in a real app this would come from an API
   const moduleData: { [key: string]: any } = {
@@ -319,7 +319,7 @@ const ModuleDetail = () => {
     },
   };
 
-  const module = moduleData[id || ''] || {
+  const module = moduleData[id] || {
     title: 'Module Not Found',
     category: 'Unknown',
     description: 'This module is not available or the link is incorrect.',


### PR DESCRIPTION
## Summary
- remove `useParams` from chat-room module page
- hardcode the chat-room id so the proper data loads

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6842c2634a688327ac86eac8ea7d27e5