### PR TITLE
Enable module scrolling via arrows

### DIFF
--- a/src/components/ModuleNav.tsx
+++ b/src/components/ModuleNav.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom';
+import { ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { modulesList } from '@/lib/modules';
+
+interface ModuleNavProps {
+  currentId: string;
+}
+
+export default function ModuleNav({ currentId }: ModuleNavProps) {
+  const index = modulesList.findIndex((m) => m.id === currentId);
+  if (index === -1) return null;
+
+  const prevModule = modulesList[(index - 1 + modulesList.length) % modulesList.length];
+  const nextModule = modulesList[(index + 1) % modulesList.length];
+
+  return (
+    <div className="sticky top-[56px] bg-white py-4 z-20 shadow-sm">
+      <div className="container mx-auto px-4 flex justify-between items-center">
+        <Link
+          to={prevModule.path}
+          className="flex items-center space-x-2 font-poppins font-semibold text-gray-700"
+        >
+          <ChevronsLeft size={32} strokeWidth={3} />
+          <span>{prevModule.title}</span>
+        </Link>
+        <Link
+          to={nextModule.path}
+          className="flex items-center space-x-2 font-poppins font-semibold text-gray-700"
+        >
+          <span>{nextModule.title}</span>
+          <ChevronsRight size={32} strokeWidth={3} />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -1,0 +1,26 @@
+export interface ModuleInfo {
+  id: string;
+  title: string;
+  path: string;
+  color: string;
+}
+
+export const modulesList: ModuleInfo[] = [
+  { id: 'alarm', title: 'Alarm', path: '/modules/alarm', color: '#fbc02d' },
+  { id: 'bulletin-board', title: 'Bulletin Board', path: '/modules/bulletin-board', color: '#fdc107' },
+  { id: 'chat-room', title: 'Chat Room', path: '/modules/chat-room', color: '#4baf4f' },
+  { id: 'documents', title: 'Documents', path: '/modules/documents', color: '#fe9100' },
+  { id: 'home-repairs', title: 'Home Repairs', path: '/modules/home-repairs', color: '#f3372b' },
+  { id: 'local-posts', title: 'Local Posts', path: '/modules/local-posts', color: '#9c27b0' },
+  { id: 'marketplace', title: 'Marketplace', path: '/modules/marketplace', color: '#4caf50' },
+  { id: 'noise-alerts', title: 'Noise Alerts', path: '/modules/noise-alerts', color: '#e91e63' },
+  { id: 'official-notices', title: 'Official Notices', path: '/modules/official-notices', color: '#3f51b5' },
+  { id: 'parking-sharing', title: 'Parking Sharing', path: '/modules/parking-sharing', color: '#795548' },
+  { id: 'quiz', title: 'Quiz', path: '/modules/quiz', color: '#009688' },
+  { id: 'security', title: 'Security', path: '/modules/security', color: '#607d8b' },
+  { id: 'shared-rides', title: 'Ride Sharing', path: '/modules/shared-rides', color: '#86be41' },
+  { id: 'shared-tasks', title: 'Shared Tasks', path: '/modules/shared-tasks', color: '#8bc34a' },
+  { id: 'wise-owl', title: 'Wise Owl', path: '/modules/wise-owl', color: '#ffc107' },
+  { id: 'business-networking', title: 'Business Networking', path: '/modules/business-networking', color: '#3f51b5' },
+  { id: 'conference-rooms', title: 'Conference Rooms', path: '/modules/conference-rooms', color: '#9c27b0' },
+];

--- a/src/pages/modules/alarm.tsx
+++ b/src/pages/modules/alarm.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const Alarm = () => (
   <Layout>
+    <ModuleNav currentId="alarm" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/bulletin-board.tsx
+++ b/src/pages/modules/bulletin-board.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   ArrowLeft,
@@ -136,6 +137,7 @@ const BulletinBoardDetail = () => {
 
   return (
     <Layout>
+      <ModuleNav currentId="bulletin-board" />
       {/* Breadcrumb */}
       <section className="bg-conexa-light-grey py-3">
         <div className="container mx-auto px-4">

--- a/src/pages/modules/business-networking.tsx
+++ b/src/pages/modules/business-networking.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const BusinessNetworking = () => (
   <Layout>
+    <ModuleNav currentId="business-networking" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/chat-room.tsx
+++ b/src/pages/modules/chat-room.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
+import { modulesList } from '@/lib/modules';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   ArrowLeft,
@@ -10,8 +12,6 @@ import {
   Users,
   Eye,
   Lock,
-  ChevronLeft,
-  ChevronRight,
 } from 'lucide-react';
 import YouTubeEmbed from '@/components/YouTubeEmbed';
 import {
@@ -21,30 +21,6 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 
-interface ModuleInfo {
-  id: string;
-  title: string;
-  path: string;
-  color: string;
-}
-
-const modulesList: ModuleInfo[] = [
-  { id: 'alarm', title: 'Alarm', path: '/modules/alarm', color: '#fbc02d' },
-  { id: 'bulletin-board', title: 'Bulletin Board', path: '/modules/bulletin-board', color: '#fdc107' },
-  { id: 'chat-room', title: 'Chat Room', path: '/modules/chat-room', color: '#4baf4f' },
-  { id: 'documents', title: 'Documents', path: '/modules/documents', color: '#fe9100' },
-  { id: 'home-repairs', title: 'Home Repairs', path: '/modules/home-repairs', color: '#f3372b' },
-  { id: 'local-posts', title: 'Local Posts', path: '/modules/local-posts', color: '#9c27b0' },
-  { id: 'marketplace', title: 'Marketplace', path: '/modules/marketplace', color: '#4caf50' },
-  { id: 'noise-alerts', title: 'Noise Alerts', path: '/modules/noise-alerts', color: '#e91e63' },
-  { id: 'official-notices', title: 'Official Notices', path: '/modules/official-notices', color: '#3f51b5' },
-  { id: 'parking-sharing', title: 'Parking Sharing', path: '/modules/parking-sharing', color: '#795548' },
-  { id: 'quiz', title: 'Quiz', path: '/modules/quiz', color: '#009688' },
-  { id: 'security', title: 'Security', path: '/modules/security', color: '#607d8b' },
-  { id: 'shared-rides', title: 'Ride Sharing', path: '/modules/shared-rides', color: '#86be41' },
-  { id: 'shared-tasks', title: 'Shared Tasks', path: '/modules/shared-tasks', color: '#8bc34a' },
-  { id: 'wise-owl', title: 'Wise Owl', path: '/modules/wise-owl', color: '#ffc107' },
-];
 
 const ChatRoomDetail: React.FC = () => {
   const id = 'chat-room';
@@ -153,34 +129,7 @@ const ChatRoomDetail: React.FC = () => {
         </div>
       </section>
 
-      {/* Sticky Navigation Arrows */}
-      <div className="sticky top-[56px] bg-white py-4 z-20 shadow-sm">
-        <div className="container mx-auto px-4 flex justify-between items-center">
-          {prevModule ? (
-            <Link
-              to={prevModule.path}
-              className={`flex items-center space-x-2 bg-white border-2 border-[${prevModule.color}] text-[${prevModule.color}] p-3 rounded-full shadow-md hover:shadow-lg`}
-            >
-              <ChevronLeft size={32} className={`text-[${prevModule.color}]`} />
-              <span className="font-poppins font-medium">{prevModule.title}</span>
-            </Link>
-          ) : (
-            <div style={{ width: '160px' }} />
-          )}
-
-          {nextModule ? (
-            <Link
-              to={nextModule.path}
-              className={`flex items-center space-x-2 bg-white border-2 border-[${nextModule.color}] text-[${nextModule.color}] p-3 rounded-full shadow-md hover:shadow-lg`}
-            >
-              <span className="font-poppins font-medium">{nextModule.title}</span>
-              <ChevronRight size={32} className={`text-[${nextModule.color}]`} />
-            </Link>
-          ) : (
-            <div style={{ width: '160px' }} />
-          )}
-        </div>
-      </div>
+      <ModuleNav currentId="chat-room" />
 
       {/* Hero Section */}
       <section className="py-12 bg-white">

--- a/src/pages/modules/conference-rooms.tsx
+++ b/src/pages/modules/conference-rooms.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const ConferenceRooms = () => (
   <Layout>
+    <ModuleNav currentId="conference-rooms" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/documents.tsx
+++ b/src/pages/modules/documents.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   ArrowLeft,
@@ -12,8 +13,6 @@ import {
   Lock,
   FolderOpen,
   Star,
-  ChevronLeft,
-  ChevronRight,
 } from 'lucide-react';
 import {
   Accordion,
@@ -136,28 +135,7 @@ const DocumentsDetail: React.FC = () => {
         </div>
       </section>
 
-      {/* Sticky Navigation Arrows right below breadcrumb */}
-      <div className="sticky top-[56px] bg-white py-4 z-20 shadow-sm">
-        <div className="container mx-auto px-4 flex justify-between items-center">
-          {/* PREVIOUS: Home Repairs (boja #f3372b), ali samo obrub i tekst/ikona */}
-          <Link
-            to="/modules/home-repairs"
-            className="flex items-center space-x-2 bg-white border-2 border-[#f3372b] text-[#f3372b] p-3 rounded-full shadow-md hover:shadow-lg"
-          >
-            <ChevronLeft size={32} className="text-[#f3372b]" />
-            <span className="font-poppins font-medium">Home Repairs</span>
-          </Link>
-
-          {/* NEXT: Ride Sharing (boja #86be41), obrub i tekst/ikona */}
-          <Link
-            to="/modules/shared-rides"
-            className="flex items-center space-x-2 bg-white border-2 border-[#86be41] text-[#86be41] p-3 rounded-full shadow-md hover:shadow-lg"
-          >
-            <span className="font-poppins font-medium">Ride Sharing</span>
-            <ChevronRight size={32} className="text-[#86be41]" />
-          </Link>
-        </div>
-      </div>
+      <ModuleNav currentId="documents" />
 
       {/* Hero Section */}
       <section className="py-12 bg-white">

--- a/src/pages/modules/home-repairs.tsx
+++ b/src/pages/modules/home-repairs.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const HomeRepairs = () => (
   <Layout>
+    <ModuleNav currentId="home-repairs" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/local-posts.tsx
+++ b/src/pages/modules/local-posts.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const LocalPosts = () => (
   <Layout>
+    <ModuleNav currentId="local-posts" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/marketplace.tsx
+++ b/src/pages/modules/marketplace.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const Marketplace = () => (
   <Layout>
+    <ModuleNav currentId="marketplace" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/noise-alerts.tsx
+++ b/src/pages/modules/noise-alerts.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const NoiseAlerts = () => (
   <Layout>
+    <ModuleNav currentId="noise-alerts" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/official-notices.tsx
+++ b/src/pages/modules/official-notices.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const OfficialNotices = () => (
   <Layout>
+    <ModuleNav currentId="official-notices" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/parking-sharing.tsx
+++ b/src/pages/modules/parking-sharing.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const ParkingSharing = () => (
   <Layout>
+    <ModuleNav currentId="parking-sharing" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/quiz.tsx
+++ b/src/pages/modules/quiz.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const Quiz = () => (
   <Layout>
+    <ModuleNav currentId="quiz" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/security.tsx
+++ b/src/pages/modules/security.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const Security = () => (
   <Layout>
+    <ModuleNav currentId="security" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/shared-rides.tsx
+++ b/src/pages/modules/shared-rides.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const SharedRides = () => (
   <Layout>
+    <ModuleNav currentId="shared-rides" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/shared-tasks.tsx
+++ b/src/pages/modules/shared-tasks.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const SharedTasks = () => (
   <Layout>
+    <ModuleNav currentId="shared-tasks" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">

--- a/src/pages/modules/wise-owl.tsx
+++ b/src/pages/modules/wise-owl.tsx
@@ -1,7 +1,9 @@
 import Layout from '@/components/Layout';
+import ModuleNav from '@/components/ModuleNav';
 
 const WiseOwl = () => (
   <Layout>
+    <ModuleNav currentId="wise-owl" />
     <section className="py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h1 className="font-poppins font-semibold text-4xl text-gray-900">


### PR DESCRIPTION
## Summary
- add shared module list and `ModuleNav` component
- wire new navigation component into all module pages
- replace document and chat room nav markup with the shared nav

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842defea7d88327b695f49bf7288bf3