### PR TITLE
Add automatic translation and languages page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       function googleTranslateElementInit() {
         new google.translate.TranslateElement({
           pageLanguage: 'en',
-          includedLanguages: 'en,hr,de',
+          includedLanguages: 'en,hr,de,fr,tr,no,pt,fi,el,es,it,ru',
           layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
           autoDisplay: false
         }, 'google_translate_element');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import Pricing from "./pages/Pricing";
 import Benefits from "./pages/Benefits";
 import HowItWorks from "./pages/HowItWorks";
 import FAQ from "./pages/FAQ";
+import Languages from "./pages/Languages";
 import NotFound from "./pages/NotFound";
 
 function App() {
@@ -49,6 +50,7 @@ function App() {
         <Route path="/benefits" element={<Benefits />} />
         <Route path="/how-it-works" element={<HowItWorks />} />
         <Route path="/faq" element={<FAQ />} />
+        <Route path="/languages" element={<Languages />} />
 
         {/* Blog: lista i konkretni postovi */}
         <Route path="/blog" element={<Blog />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -70,6 +70,7 @@ const Footer = () => {
               <li><Link to="/blog" className="text-gray-600 hover:text-[#FF7847] transition-colors font-inter">Blog</Link></li>
               <li><Link to="/contact" className="text-gray-600 hover:text-[#FF7847] transition-colors font-inter">Contact</Link></li>
               <li><Link to="/faq" className="text-gray-600 hover:text-[#FF7847] transition-colors font-inter">FAQ</Link></li>
+              <li><Link to="/languages" className="text-gray-600 hover:text-[#FF7847] transition-colors font-inter">Languages</Link></li>
             </ul>
           </div>
         </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -22,6 +22,7 @@ const Navigation = () => {
     { label: 'Pricing', href: '/pricing' },
     { label: 'Blog', href: '/blog' },
     { label: 'Contact', href: '/contact' },
+    { label: 'Languages', href: '/languages' },
   ];
 
   const isActive = (href: string) => location.pathname === href;
@@ -46,7 +47,7 @@ const Navigation = () => {
       window.googleTranslateElementInit = () => {
         new window.google.translate.TranslateElement({
           pageLanguage: 'en',
-          includedLanguages: 'en,hr,de',
+          includedLanguages: 'en,hr,de,fr,tr,no,pt,fi,el,es,it,ru',
           autoDisplay: false,
           layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE
         });
@@ -61,13 +62,42 @@ const Navigation = () => {
         styleElement.innerHTML = css;
         document.head.appendChild(styleElement);
 
-        // Browser-language auto-switch on first visit
-        const userLang = (navigator.language || '').substring(0, 2);
+        // Auto-switch based on browser or location on first visit
+        const languages = ['en','hr','de','fr','tr','no','pt','fi','el','es','it','ru'];
+        let userLang = (navigator.language || '').substring(0, 2);
         const first = !localStorage.getItem('conexaLangSet');
-        if (first && ['hr', 'de'].includes(userLang)) {
-          translateTo(userLang);
-          localStorage.setItem('conexaLangSet', '1');
-        }
+
+        const detectByLocation = async () => {
+          try {
+            const res = await fetch('https://ipapi.co/json/');
+            const data = await res.json();
+            const map: Record<string, string> = {
+              HR: 'hr',
+              DE: 'de',
+              FR: 'fr',
+              TR: 'tr',
+              NO: 'no',
+              PT: 'pt',
+              FI: 'fi',
+              GR: 'el',
+              ES: 'es',
+              IT: 'it',
+              RU: 'ru'
+            };
+            if (data?.country_code && map[data.country_code]) {
+              userLang = map[data.country_code];
+            }
+          } catch (err) {
+            console.error('Geo detection failed', err);
+          }
+
+          if (first && languages.includes(userLang)) {
+            translateTo(userLang);
+            localStorage.setItem('conexaLangSet', '1');
+          }
+        };
+
+        detectByLocation();
       };
     };
 
@@ -144,6 +174,15 @@ const Navigation = () => {
               <option value="en">English</option>
               <option value="hr">Croatian</option>
               <option value="de">German</option>
+              <option value="fr">French</option>
+              <option value="tr">Turkish</option>
+              <option value="no">Norwegian</option>
+              <option value="pt">Portuguese</option>
+              <option value="fi">Finnish</option>
+              <option value="el">Greek</option>
+              <option value="es">Spanish</option>
+              <option value="it">Italian</option>
+              <option value="ru">Russian</option>
             </select>
 
             <Button 
@@ -200,6 +239,15 @@ const Navigation = () => {
                   <option value="en">English</option>
                   <option value="hr">Croatian</option>
                   <option value="de">German</option>
+                  <option value="fr">French</option>
+                  <option value="tr">Turkish</option>
+                  <option value="no">Norwegian</option>
+                  <option value="pt">Portuguese</option>
+                  <option value="fi">Finnish</option>
+                  <option value="el">Greek</option>
+                  <option value="es">Spanish</option>
+                  <option value="it">Italian</option>
+                  <option value="ru">Russian</option>
                 </select>
 
                 <Button 

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -29,7 +29,7 @@ const FAQ = () => {
     },
     {
       question: "What languages does Conexa support?",
-      answer: "Currently, Conexa is available in English and Croatian. We're expanding to German, Italian, and Spanish in 2025. All modules support multi-language content from residents."
+      answer: "Conexa is available in multiple languages including English, Croatian, German, French, Turkish, Norwegian, Portuguese, Finnish, Greek, Spanish, Italian and Russian. All modules support multi-language content from residents."
     },
     {
       question: "Do I need technical skills to use Conexa?",

--- a/src/pages/Languages.tsx
+++ b/src/pages/Languages.tsx
@@ -1,0 +1,40 @@
+import Layout from '@/components/Layout';
+
+const Languages = () => {
+  const languages = [
+    'English',
+    'Croatian',
+    'German',
+    'French',
+    'Turkish',
+    'Norwegian',
+    'Portuguese',
+    'Finnish',
+    'Greek',
+    'Spanish',
+    'Italian',
+    'Russian'
+  ];
+
+  return (
+    <Layout>
+      <section className="bg-gradient-to-br from-conexa-light-grey to-white py-20">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="font-poppins font-semibold text-4xl lg:text-5xl text-gray-900 mb-6">
+            Supported Languages in Conexa
+          </h1>
+          <p className="font-inter text-xl text-gray-600 max-w-3xl mx-auto">
+            Conexa currently supports the following languages:
+          </p>
+          <ul className="mt-6 space-y-2 font-inter text-gray-700">
+            {languages.map((lang) => (
+              <li key={lang}>{lang}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default Languages;


### PR DESCRIPTION
## Summary
- integrate Google Translate with many languages and auto-detection based on location
- update navigation with Languages link and extended language options
- add new `/languages` page listing supported languages
- update FAQ with new language list
- link to Languages page in footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845cbf0a4e08327b6fc4ad2ee52bdee