### PR TITLE
Load Google Translate only in React

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,17 +20,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     
-    <script type="text/javascript">
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'en,hr,de,fr,tr,no,pt,fi,el,es,it,ru',
-          layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-          autoDisplay: false
-        }, 'google_translate_element');
-      }
-    </script>
-    <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <!-- Google Translate is loaded dynamically in Navigation.tsx -->
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- remove the Google Translate initialization from `index.html`
- rely on `Navigation.tsx` to insert the script at runtime

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845d39173c08327bace3597540216d0