### PR TITLE
Add popup notice for Google Translate usage

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,8 +9,8 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
       <Navigation />
-      {/* Hidden container required for Google Translate */}
-      <div id="google_translate_element" className="hidden" />
+      {/* Container for Google Translate */}
+      <div id="google_translate_element" />
       <main className="flex-1 pt-16">
         {children}
       </main>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -45,22 +45,14 @@ const Navigation = () => {
       document.body.appendChild(script);
 
       window.googleTranslateElementInit = () => {
-        new window.google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'en,hr,de,fr,tr,no,pt,fi,el,es,it,ru',
-          autoDisplay: false,
-          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE
-        });
-
-        // Hide default Google elements
-        const css = `
-          .goog-logo-link, .goog-te-gadget span, .goog-te-banner-frame { display:none!important }
-          body { top:0!important }
-          .goog-te-combo { position: absolute; left: -9999px; opacity: 0; }
-        `;
-        const styleElement = document.createElement('style');
-        styleElement.innerHTML = css;
-        document.head.appendChild(styleElement);
+        new window.google.translate.TranslateElement(
+          {
+            pageLanguage: 'en',
+            includedLanguages: 'en,hr,de,fr,tr,no,pt,fi,el,es,it,ru',
+            layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+          },
+          'google_translate_element'
+        );
 
         // Auto-switch based on browser or location on first visit
         const languages = ['en','hr','de','fr','tr','no','pt','fi','el','es','it','ru'];
@@ -143,6 +135,9 @@ const Navigation = () => {
       const target = e.target as HTMLSelectElement;
       if (target.id === 'lang-select' || target.id === 'lang-select-mobile') {
         translateTo(target.value);
+        alert(
+          'This is an automatic translation of the page. We apologise for any errors in the text and thank you for your understanding.'
+        );
       }
     };
 


### PR DESCRIPTION
## Summary
- display Google Translate widget in layout
- initialize translator on the widget element
- alert user about automatic translation when changing language

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684611a5d14483279d2bc78c38d52230