### PR TITLE
Add i18n to languages and not-found pages

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -8,5 +8,13 @@
     "contact": "Kontakt",
     "languages": "Sprachen",
     "startFree": "Jetzt kostenlos starten"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/el/translation.json
+++ b/src/locales/el/translation.json
@@ -8,5 +8,13 @@
     "contact": "Επικοινωνία",
     "languages": "Γλώσσες",
     "startFree": "Ξεκινήστε δωρεάν"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,5 +8,13 @@
     "contact": "Contact",
     "languages": "Languages",
     "startFree": "Start Free Today"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -8,5 +8,13 @@
     "contact": "Contacto",
     "languages": "Idiomas",
     "startFree": "Empieza gratis"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -8,5 +8,13 @@
     "contact": "Yhteystiedot",
     "languages": "Kielet",
     "startFree": "Aloita ilmaiseksi"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -8,5 +8,13 @@
     "contact": "Contact",
     "languages": "Langues",
     "startFree": "Commencez gratuitement"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/hr/translation.json
+++ b/src/locales/hr/translation.json
@@ -8,5 +8,13 @@
     "contact": "Kontakt",
     "languages": "Jezici",
     "startFree": "Započni besplatno"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -8,5 +8,13 @@
     "contact": "Contatto",
     "languages": "Lingue",
     "startFree": "Inizia gratis"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/no/translation.json
+++ b/src/locales/no/translation.json
@@ -8,5 +8,13 @@
     "contact": "Kontakt",
     "languages": "Språk",
     "startFree": "Start gratis"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -8,5 +8,13 @@
     "contact": "Contato",
     "languages": "Idiomas",
     "startFree": "Comece gratuitamente"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -8,5 +8,13 @@
     "contact": "Контакты",
     "languages": "Языки",
     "startFree": "Начать бесплатно"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -8,5 +8,13 @@
     "contact": "İletişim",
     "languages": "Diller",
     "startFree": "Ücretsiz Başlayın"
+  },
+  "notFound": {
+    "message": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  },
+  "languages": {
+    "title": "Supported Languages in Conexa",
+    "description": "The following languages are supported in the Conexa application:"
   }
 }

--- a/src/pages/Languages.tsx
+++ b/src/pages/Languages.tsx
@@ -1,6 +1,8 @@
 import Layout from "@/components/Layout";
+import { useTranslation } from "react-i18next";
 
 const Languages = () => {
+  const { t } = useTranslation();
   const languages = [
     { name: "English", flag: "🇬🇧" },
     { name: "العربية", flag: "🇦🇪" },
@@ -38,10 +40,10 @@ const Languages = () => {
       <section className="bg-gradient-to-br from-conexa-light-grey to-white py-20">
         <div className="container mx-auto px-4 text-center">
           <h1 className="font-poppins font-semibold text-4xl lg:text-5xl text-gray-900 mb-6">
-            Supported Languages in Conexa
+            {t('languages.title')}
           </h1>
           <p className="font-inter text-xl text-gray-600 max-w-3xl mx-auto">
-            The following languages are supported in the Conexa application:
+            {t('languages.description')}
           </p>
           <div className="mt-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-8">
             {languages.map((lang) => (

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,8 +1,10 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 
 const NotFound = () => {
   const location = useLocation();
+  const { t } = useTranslation();
 
   useEffect(() => {
     console.error(
@@ -15,9 +17,9 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-600 mb-4">{t('notFound.message')}</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
+          {t('notFound.returnHome')}
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- internationalize the NotFound page
- internationalize the Languages page
- extend translation files with notFound and languages keys

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68461b5e224483279428fdcbfcef6891