### PR TITLE
feat(i18n): persist language preference

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -33,6 +33,13 @@ const Navigation = () => {
 
   const { t, i18n } = useTranslation();
 
+  const changeLanguage = (lang: string) => {
+    i18n.changeLanguage(lang);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('language', lang);
+    }
+  };
+
   useEffect(() => {
     document.documentElement.lang = i18n.language;
   }, [i18n.language]);
@@ -80,7 +87,7 @@ const Navigation = () => {
               aria-label="Select site language"
               className="h-9 px-3 text-sm font-inter text-gray-700 bg-white border border-gray-300 rounded-md appearance-none focus:outline-none focus:ring-2 focus:ring-[#FF7847] focus:border-transparent transition-all"
               value={i18n.language}
-              onChange={(e) => i18n.changeLanguage(e.target.value)}
+              onChange={(e) => changeLanguage(e.target.value)}
             >
               <option value="en">English</option>
               <option value="hr">Croatian</option>
@@ -147,7 +154,7 @@ const Navigation = () => {
                   aria-label="Select site language"
                   className="h-12 px-3 text-sm font-inter text-gray-700 bg-white border border-gray-300 rounded-md appearance-none focus:outline-none focus:ring-2 focus:ring-[#FF7847] focus:border-transparent transition-all"
                   value={i18n.language}
-                  onChange={(e) => i18n.changeLanguage(e.target.value)}
+                  onChange={(e) => changeLanguage(e.target.value)}
                 >
                   <option value="en">English</option>
                   <option value="hr">Croatian</option>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -14,6 +14,9 @@ import es from '@/locales/es/translation.json';
 import it from '@/locales/it/translation.json';
 import ru from '@/locales/ru/translation.json';
 
+const storedLanguage =
+  typeof window !== 'undefined' ? localStorage.getItem('language') : null;
+
 void i18n
   .use(initReactI18next)
   .init({
@@ -31,7 +34,7 @@ void i18n
       it: { translation: it },
       ru: { translation: ru },
     },
-    lng: 'en',
+    lng: storedLanguage ?? 'en',
     fallbackLng: 'en',
     interpolation: { escapeValue: false },
   });


### PR DESCRIPTION
## Summary
- persist user language choice after changing language in Navigation
- load stored language when initializing i18n

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68461c3e9594832798960375e7777ffd