### PR TITLE
Remove unused Google Translate comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     
-    <!-- Google Translate is loaded dynamically in Navigation.tsx -->
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- clean up `index.html` by removing a stale comment referencing Google Translate

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68461d9a01f48327a082947c8da63e3c