### PR TITLE
Integrate Google Translate with custom language dropdown

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+const languages = [
+  { code: 'hr', label: 'HR' },
+  { code: 'en', label: 'EN' },
+  { code: 'de', label: 'DE' },
+  { code: 'fr', label: 'FR' },
+  { code: 'it', label: 'IT' },
+  { code: 'es', label: 'ES' },
+  { code: 'pt', label: 'PT' },
+  { code: 'nl', label: 'NL' },
+  { code: 'pl', label: 'PL' },
+  { code: 'bs', label: 'BS' }
+];
+
+const LanguageSelector = () => {
+  useEffect(() => {
+    if (!(window as any).googleTranslateElementInit) {
+      (window as any).googleTranslateElementInit = () => {
+        new (window as any).google.translate.TranslateElement(
+          {
+            pageLanguage: 'hr',
+            includedLanguages: languages.map((l) => l.code).join(','),
+            autoDisplay: false,
+          },
+          'google_translate_element'
+        );
+      };
+      const script = document.createElement('script');
+      script.id = 'google-translate';
+      script.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+      document.body.appendChild(script);
+    }
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    const combo = document.querySelector<HTMLSelectElement>('.goog-te-combo');
+    if (combo) {
+      combo.value = lang;
+      combo.dispatchEvent(new Event('change'));
+    }
+  };
+
+  return (
+    <div>
+      <select onChange={handleChange} className="border rounded px-2 py-1 text-sm">
+        {languages.map(({ code, label }) => (
+          <option key={code} value={code}>
+            {label}
+          </option>
+        ))}
+      </select>
+      <div id="google_translate_element" className="hidden" />
+    </div>
+  );
+};
+
+export default LanguageSelector;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
+import LanguageSelector from './LanguageSelector';
 
 const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -66,8 +67,9 @@ const Navigation = () => {
             ))}
           </div>
 
-          {/* CTA Button */}
-          <div className="hidden lg:flex items-center">
+          {/* CTA Button and Language */}
+          <div className="hidden lg:flex items-center space-x-4">
+            <LanguageSelector />
             <Button
               className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm transition-all hover:scale-105 shadow-sm"
               asChild
@@ -113,6 +115,7 @@ const Navigation = () => {
               ))}
 
               <div className="flex flex-col space-y-3 pt-4 border-t border-gray-100">
+                <LanguageSelector />
                 <Button
                   className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm h-12 w-full"
                   asChild

--- a/src/index.css
+++ b/src/index.css
@@ -75,3 +75,13 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Hide Google Translate default elements */
+.goog-te-banner-frame,
+.goog-logo-link,
+#google_translate_element,
+.goog-te-gadget {
+  display: none !important;
+}
+body { top: 0 !important; }
+


### PR DESCRIPTION
## Summary
- add `LanguageSelector` component using official Google Translate loader
- embed the selector in navigation for desktop and mobile views
- hide Google default banner and widget elements via CSS

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846314c54e483279ef466b78e537a05