### PR TITLE
Update CSS to hide Google Translate banner

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -78,9 +78,12 @@
 
 /* Hide Google Translate default elements */
 .goog-te-banner-frame,
+.goog-te-banner-frame.skiptranslate,
 .goog-logo-link,
 #google_translate_element,
-.goog-te-gadget {
+.goog-te-gadget,
+#goog-gt-tt,
+.goog-tooltip {
   display: none !important;
 }
 body { top: 0 !important; }


### PR DESCRIPTION
## Summary
- hide Google Translate banners, iframes, and tooltips

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684637e5f3188327949b0174ddeb082f