### PR TITLE
Fix LanguageSelector translation handling

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const languages = [
   { code: 'hr', label: 'HR' },
@@ -14,6 +14,7 @@ const languages = [
 ];
 
 const LanguageSelector = () => {
+  const selectRef = useRef<HTMLSelectElement>(null);
   useEffect(() => {
     if (!(window as any).googleTranslateElementInit) {
       (window as any).googleTranslateElementInit = () => {
@@ -25,11 +26,41 @@ const LanguageSelector = () => {
           },
           'google_translate_element'
         );
+
+        const combo = document.querySelector<HTMLSelectElement>('.goog-te-combo');
+        if (combo) {
+          combo.classList.add('notranslate');
+          combo.setAttribute('translate', 'no');
+          combo.querySelectorAll('option').forEach((option) => {
+            option.setAttribute('data-label', option.textContent ?? '');
+            option.classList.add('notranslate');
+            option.setAttribute('translate', 'no');
+          });
+          const restore = () => {
+            combo.querySelectorAll('option').forEach((option) => {
+              const label = option.getAttribute('data-label');
+              if (label) option.textContent = label;
+            });
+          };
+          combo.addEventListener('change', restore);
+          const observer = new MutationObserver(restore);
+          observer.observe(combo, { childList: true, subtree: true, characterData: true });
+        }
       };
       const script = document.createElement('script');
       script.id = 'google-translate';
       script.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
       document.body.appendChild(script);
+    }
+
+    if (selectRef.current) {
+      const select = selectRef.current;
+      select.classList.add('notranslate');
+      select.setAttribute('translate', 'no');
+      select.querySelectorAll('option').forEach((option) => {
+        option.classList.add('notranslate');
+        option.setAttribute('translate', 'no');
+      });
     }
   }, []);
 
@@ -44,9 +75,13 @@ const LanguageSelector = () => {
 
   return (
     <div>
-      <select onChange={handleChange} className="border rounded px-2 py-1 text-sm">
+      <select
+        onChange={handleChange}
+        className="border rounded px-2 py-1 text-sm"
+        ref={selectRef}
+      >
         {languages.map(({ code, label }) => (
-          <option key={code} value={code}>
+          <option key={code} value={code} data-label={label}>
             {label}
           </option>
         ))}


### PR DESCRIPTION
## Summary
- preserve language option labels by storing them in `data-label`
- mark the selector and options as `notranslate`
- restore Google Translate dropdown labels after translation

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463878dc4c83278c211c31be2c2bc9