### PR TITLE
Fix LanguageSelector translation handling

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const languages = [
   { code: 'hr', label: 'HR' },
@@ -14,6 +14,7 @@ const languages = [
 ];
 
 const LanguageSelector = () => {
+  const selectRef = useRef<HTMLSelectElement>(null);
   useEffect(() => {
     if (!(window as any).googleTranslateElementInit) {
       (window as any).googleTranslateElementInit = () => {
@@ -25,11 +26,41 @@ const LanguageSelector = () => {
           },
           'google_translate_element'
         );
+
+        const combo = document.querySelector<HTMLSelectElement>('.goog-te-combo');
+        if (combo) {
+          combo.classList.add('notranslate');
+          combo.setAttribute('translate', 'no');
+          combo.querySelectorAll('option').forEach((option) => {
+            option.setAttribute('data-label', option.textContent ?? '');
+            option.classList.add('notranslate');
+            option.setAttribute('translate', 'no');
+          });
+          const restore = () => {
+            combo.querySelectorAll('option').forEach((option) => {
+              const label = option.getAttribute('data-label');
+              if (label) option.textContent = label;
+            });
+          };
+          combo.addEventListener('change', restore);
+          const observer = new MutationObserver(restore);
+          observer.observe(combo, { childList: true, subtree: true, characterData: true });
+        }
       };
       const script = document.createElement('script');
       script.id = 'google-translate';
       script.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
       document.body.appendChild(script);
+    }
+
+    if (selectRef.current) {
+      const select = selectRef.current;
+      select.classList.add('notranslate');
+      select.setAttribute('translate', 'no');
+      select.querySelectorAll('option').forEach((option) => {
+        option.classList.add('notranslate');
+        option.setAttribute('translate', 'no');
+      });
     }
   }, []);
 
@@ -44,9 +75,13 @@ const LanguageSelector = () => {
 
   return (
     <div>
-      <select onChange={handleChange} className="border rounded px-2 py-1 text-sm">
+      <select
+        onChange={handleChange}
+        className="border rounded px-2 py-1 text-sm"
+        ref={selectRef}
+      >
         {languages.map(({ code, label }) => (
-          <option key={code} value={code}>
+          <option key={code} value={code} data-label={label}>
             {label}
           </option>
         ))}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import Navigation from './Navigation';
 import Footer from './Footer';
 
@@ -6,10 +7,29 @@ interface LayoutProps {
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const [toolbarHeight, setToolbarHeight] = useState(0);
+
+  useEffect(() => {
+    const update = () => {
+      const banner = document.querySelector<HTMLIFrameElement>('.goog-te-banner-frame');
+      const height = banner ? banner.getBoundingClientRect().height : 0;
+      setToolbarHeight(height);
+    };
+
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener('resize', update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <Navigation />
-      <main className="flex-1 pt-16">
+      <Navigation offset={toolbarHeight} />
+      <main className="flex-1" style={{ paddingTop: 64 + toolbarHeight }}>
         {children}
       </main>
       <Footer />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,7 +4,11 @@ import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
 import LanguageSelector from './LanguageSelector';
 
-const Navigation = () => {
+interface NavigationProps {
+  offset?: number;
+}
+
+const Navigation = ({ offset = 0 }: NavigationProps) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
@@ -33,13 +37,16 @@ const Navigation = () => {
   const ctaLabel = 'Start Free Today';
 
   return (
-    <nav className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-      isScrolled 
-        ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm translate-y-0' 
-        : location.pathname === '/' 
-          ? 'bg-transparent translate-y-0' 
-          : 'bg-white/95 backdrop-blur-sm border-b border-gray-100 translate-y-0'
-    }`}>
+    <nav
+      style={{ top: offset }}
+      className={`fixed left-0 right-0 z-50 transition-all duration-300 ${
+        isScrolled
+          ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm translate-y-0'
+          : location.pathname === '/'
+            ? 'bg-transparent translate-y-0'
+            : 'bg-white/95 backdrop-blur-sm border-b border-gray-100 translate-y-0'
+      }`}
+    >
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}


### PR DESCRIPTION
## Summary
- preserve language option labels by storing them in `data-label`
- mark the selector and options as `notranslate`
- restore Google Translate dropdown labels after translation
- shift the navigation header down whenever the Google toolbar appears

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68463878dc4c83278c211c31be2c2bc9