### PR TITLE
Add i18n translation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Translation script
+
+Run `node translate.js` to generate German (`de`), Croatian (`hr`) and Spanish (`es`) locale files using the Google Cloud Translation API. Place your API key in a `.env` file as `GOOGLE_API_KEY=YOUR_KEY` before executing.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,14 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 export default [
   { ignores: ['dist'] },
   {
+    files: ['translate.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      globals: globals.node,
+      sourceType: 'module',
+    },
+  },
+  {
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.4.1",
         "embla-carousel-react": "^8.3.0",
         "i18next": "^25.2.1",
         "input-otp": "^1.2.4",
@@ -3896,6 +3897,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dotenv": "^16.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/translate.js
+++ b/translate.js
@@ -1,0 +1,113 @@
+/**
+ * Translate english locale file using Google Cloud Translation API.
+ * Set GOOGLE_API_KEY in a .env file and run `node translate.js`.
+ */
+import fs from 'fs/promises';
+import { config } from 'dotenv';
+
+config();
+
+const API_KEY = process.env.GOOGLE_API_KEY;
+
+if (!API_KEY) {
+  console.error('GOOGLE_API_KEY not set in .env');
+  process.exit(1);
+}
+
+const MAX_CHARS = 5000;
+const BASE_PATH = 'public/locales';
+const BASE_LANG = 'en';
+const TARGET_LANGS = ['de', 'hr', 'es'];
+
+function flatten(obj, prefix = '') {
+  const res = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object') {
+      Object.assign(res, flatten(value, newKey));
+    } else {
+      res[newKey] = String(value);
+    }
+  }
+  return res;
+}
+
+function unflatten(obj) {
+  const res = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const parts = key.split('.');
+    let curr = res;
+    parts.forEach((p, i) => {
+      if (i === parts.length - 1) {
+        curr[p] = value;
+      } else {
+        curr[p] = curr[p] || {};
+        curr = curr[p];
+      }
+    });
+  }
+  return res;
+}
+
+async function translateText(texts, target) {
+  const url = `https://translation.googleapis.com/language/translate/v2?key=${API_KEY}`;
+  const body = {
+    q: texts,
+    target,
+    source: 'en',
+    format: 'text'
+  };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) {
+    throw new Error(`Translation API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.data.translations.map(t => t.translatedText);
+}
+
+async function main() {
+  const baseFile = `${BASE_PATH}/${BASE_LANG}/translation.json`;
+  const enContent = JSON.parse(await fs.readFile(baseFile, 'utf-8'));
+  const flat = flatten(enContent);
+  const entries = Object.entries(flat);
+
+  // create batches respecting MAX_CHARS
+  const batches = [];
+  let current = [];
+  let size = 0;
+  for (const [k, v] of entries) {
+    const len = v.length;
+    if (size + len > MAX_CHARS && current.length) {
+      batches.push(current);
+      current = [];
+      size = 0;
+    }
+    current.push([k, v]);
+    size += len;
+  }
+  if (current.length) batches.push(current);
+
+  for (const lang of TARGET_LANGS) {
+    const translated = {};
+    for (const batch of batches) {
+      const texts = batch.map(([, v]) => v);
+      const result = await translateText(texts, lang);
+      batch.forEach(([key], idx) => {
+        translated[key] = result[idx];
+      });
+    }
+    const output = unflatten(translated);
+    const dest = `${BASE_PATH}/${lang}/translation.json`;
+    await fs.writeFile(dest, JSON.stringify(output, null, 2));
+    console.log(`Saved ${dest}`);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- automate Google translation of locale files with `translate.js`
- document translation script usage
- allow `.env` file for API key
- install `dotenv` and update lint config

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846b5252f888327ac0032f8532ac425