### PR TITLE
Improve localization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "dotenv": "^16.4.1",
         "embla-carousel-react": "^8.3.0",
         "i18next": "^25.2.1",
+        "i18next-browser-languagedetector": "^8.1.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -4544,6 +4545,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.1.0.tgz",
+      "integrity": "sha512-mHZxNx1Lq09xt5kCauZ/4bsXOEA2pfpwSoU11/QTJB+pD94iONFwp+ohqi///PwiFvjFOxe1akYCdHyFo1ng5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.4.1",
     "embla-carousel-react": "^8.3.0",
     "i18next": "^25.2.1",
+    "i18next-browser-languagedetector": "^8.1.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
@@ -63,8 +65,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "dotenv": "^16.4.1"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,23 +1,20 @@
-import i18n from '@/lib/i18n';
-
-const languages = [
-  { code: 'en', label: 'EN' },
-  { code: 'de', label: 'DE' },
-  { code: 'hr', label: 'HR' },
-  { code: 'es', label: 'ES' },
-];
+import { useState } from 'react';
+import i18n, { supportedLanguages } from '@/lib/i18n';
 
 const LanguageSelector = () => {
+  const [lang, setLang] = useState(i18n.language);
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const lang = e.target.value;
-    i18n.changeLanguage(lang);
+    const newLang = e.target.value;
+    i18n.changeLanguage(newLang);
+    setLang(newLang);
   };
 
   return (
-    <select onChange={handleChange} className="border rounded px-2 py-1 text-sm">
-      {languages.map(({ code, label }) => (
+    <select value={lang} onChange={handleChange} className="border rounded px-2 py-1 text-sm">
+      {supportedLanguages.map((code) => (
         <option key={code} value={code}>
-          {label}
+          {code.toUpperCase()}
         </option>
       ))}
     </select>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import Navigation from './Navigation';
 import Footer from './Footer';
 
@@ -7,29 +6,10 @@ interface LayoutProps {
 }
 
 const Layout = ({ children }: LayoutProps) => {
-  const [toolbarHeight, setToolbarHeight] = useState(0);
-
-  useEffect(() => {
-    const update = () => {
-      const banner = document.querySelector<HTMLIFrameElement>('.goog-te-banner-frame');
-      const height = banner ? banner.getBoundingClientRect().height : 0;
-      setToolbarHeight(height);
-    };
-
-    update();
-    const observer = new MutationObserver(update);
-    observer.observe(document.body, { childList: true, subtree: true });
-    window.addEventListener('resize', update);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', update);
-    };
-  }, []);
-
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <Navigation offset={toolbarHeight} />
-      <main className="flex-1" style={{ paddingTop: 64 + toolbarHeight }}>
+      <Navigation />
+      <main className="flex-1" style={{ paddingTop: 64 }}>
         {children}
       </main>
       <Footer />

--- a/src/index.css
+++ b/src/index.css
@@ -76,15 +76,4 @@
   }
 }
 
-/* Hide Google Translate default elements */
-.goog-te-banner-frame,
-.goog-te-banner-frame.skiptranslate,
-.goog-logo-link,
-#google_translate_element,
-.goog-te-gadget,
-#goog-gt-tt,
-.goog-tooltip {
-  display: none !important;
-}
-body { top: 0 !important; }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,31 +1,35 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import enTranslation from '../../public/locales/en/translation.json';
-import deTranslation from '../../public/locales/de/translation.json';
-import hrTranslation from '../../public/locales/hr/translation.json';
-import esTranslation from '../../public/locales/es/translation.json';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+const modules = import.meta.glob('../../public/locales/*/translation.json', { eager: true });
+
+type Resources = Record<string, { translation: any }>;
+
+const resources: Resources = {};
+export const supportedLanguages: string[] = [];
+
+for (const path in modules) {
+  const match = path.match(/public\/locales\/([^/]+)\/translation\.json$/);
+  if (match) {
+    const lang = match[1];
+    supportedLanguages.push(lang);
+    resources[lang] = { translation: (modules[path] as any).default };
+  }
+}
 
 i18n
+  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources: {
-      en: {
-        translation: enTranslation,
-      },
-      de: {
-        translation: deTranslation,
-      },
-      hr: {
-        translation: hrTranslation,
-      },
-      es: {
-        translation: esTranslation,
-      },
-    },
-    lng: 'en',
+    resources,
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false,
+    },
+    detection: {
+      lookupLocalStorage: 'i18nextLng',
+      caches: ['localStorage'],
     },
   });
 


### PR DESCRIPTION
## Summary
- remove leftover Google translate CSS
- clean up layout banner logic
- dynamically load translation files
- persist and detect language selection with i18next-browser-languagedetector
- update language selector to use dynamic language list
- add language detector dependency

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846eee71d288327a73675c172f8652f