### PR TITLE
Enhance multilingual support

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,22 +1,27 @@
 import { useState } from 'react';
-import i18n, { supportedLanguages } from '@/lib/i18n';
+import { useTranslation } from 'react-i18next';
+import { supportedLanguages } from '@/lib/i18n';
 
 const LanguageSelector = () => {
-  const [lang, setLang] = useState(i18n.language);
+  const { i18n: i18next } = useTranslation();
+  const [lang, setLang] = useState(i18next.language);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newLang = e.target.value;
-    i18n.changeLanguage(newLang);
+    i18next.changeLanguage(newLang);
     setLang(newLang);
   };
 
   return (
     <select value={lang} onChange={handleChange} className="border rounded px-2 py-1 text-sm">
-      {supportedLanguages.map((code) => (
-        <option key={code} value={code}>
-          {code.toUpperCase()}
-        </option>
-      ))}
+      {supportedLanguages.map((code) => {
+        const label = new Intl.DisplayNames([i18next.language], { type: 'language' }).of(code);
+        return (
+          <option key={code} value={code}>
+            {label ?? code.toUpperCase()}
+          </option>
+        );
+      })}
     </select>
   );
 };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,19 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    document.documentElement.lang = i18n.language;
+  }, [i18n.language]);
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
       <Navigation />

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -25,10 +25,12 @@ i18n
   .init({
     resources,
     fallbackLng: 'en',
+    supportedLngs: supportedLanguages,
     interpolation: {
       escapeValue: false,
     },
     detection: {
+      order: ['localStorage', 'navigator', 'htmlTag', 'querystring'],
       lookupLocalStorage: 'i18nextLng',
       caches: ['localStorage'],
     },


### PR DESCRIPTION
## Summary
- update i18n detection order and supported languages
- sync `<html lang>` with current locale
- display language names in selector using browser locale

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846fc2d5b448327925770af55992359