### PR TITLE
Fix DOM nesting in video links

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -100,31 +100,30 @@ const Index = () => {
         <section className="py-6 bg-white border-b border-gray-100">
           <div className="container mx-auto px-4">
             <div className="text-center">
-              <a
-                href="https://www.youtube.com/shorts/82Nsgn200iM"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-3 text-conexa-primary hover:text-blue-700 transition-colors"
-              >
-                <Play className="w-8 h-8" />
-                <div className="flex flex-col items-center">
-  <span className="font-poppins font-semibold text-xl md:text-2xl">
-    {t('index.watch_video')}
-  </span>
-  <a
-    href="https://www.youtube.com/watch?v=K-08rgQU75U&feature=youtu.be"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="inline-flex items-center justify-center gap-2 text-orange-500 hover:text-orange-700 mt-2 transition-colors"
-  >
-    <Megaphone className="w-5 h-5" />
-    <span className="font-inter font-medium text-base">
-      {t('index.listen_podcast')}
-    </span>
-  </a>
-</div>
-
-              </a>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.youtube.com/shorts/82Nsgn200iM"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-3 text-conexa-primary hover:text-blue-700 transition-colors"
+                >
+                  <Play className="w-8 h-8" />
+                  <span className="font-poppins font-semibold text-xl md:text-2xl">
+                    {t('index.watch_video')}
+                  </span>
+                </a>
+                <a
+                  href="https://www.youtube.com/watch?v=K-08rgQU75U&feature=youtu.be"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 text-orange-500 hover:text-orange-700 mt-2 transition-colors"
+                >
+                  <Megaphone className="w-5 h-5" />
+                  <span className="font-inter font-medium text-base">
+                    {t('index.listen_podcast')}
+                  </span>
+                </a>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- separate video and podcast links on homepage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68484f4ff090832797fedbfffd237af1