### PR TITLE
Fix language switcher path

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -11,7 +11,9 @@ i18n
     fallbackLng: 'en',
     interpolation: { escapeValue: false },
     backend: {
-      loadPath: '/locales/{{lng}}/translation.json',
+      // Use a relative path so translations load correctly even when the app is
+      // served from a subfolder
+      loadPath: 'locales/{{lng}}/translation.json',
     },
   });
 


### PR DESCRIPTION
## Summary
- fix i18next backend path so translation files load correctly when hosted from a subfolder

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684854ccee008327a76b8501d374aec4