### PR TITLE
Fix i18n load path to use BASE_URL

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -11,9 +11,10 @@ i18n
     fallbackLng: 'en',
     interpolation: { escapeValue: false },
     backend: {
-      // Use a relative path so translations load correctly even when the app is
-      // served from a subfolder
-      loadPath: 'locales/{{lng}}/translation.json',
+      // Use BASE_URL to resolve the translations relative to the Vite base
+      // path so that they load correctly regardless of the deployment
+      // subfolder
+      loadPath: `${import.meta.env.BASE_URL}locales/{{lng}}/translation.json`,
     },
   });
 


### PR DESCRIPTION
## Summary
- adjust i18n backend load path to include Vite `BASE_URL`
- tested dev server and build output

## Testing
- `npm run dev` (visited localhost and translation files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848582deec88327afa610a23d5e66c7